### PR TITLE
corrected key lookup bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (obj, sheetname, delimiter, filter) {
         var fo = flat(input[i], delimiter, filter);
         var keys = Object.keys(fo);
         for (var j = 0; j < keys.length; j++ ) {
-            if ( headers.indexOf(keys[j] < 0)) {
+            if ( headers.indexOf(keys[j]) < 0) {
                 headers.push(keys[j]);
             }
         }


### PR DESCRIPTION
Simple typo is causing multiplying the number of headers by the number of rows, causing duplication of data

`headers.indexOf(keys[j] < 0)` is passing boolean to `indexOf()` due to misplaced parenthesis. Changed to `headers.indexOf(keys[j]) < 0`.
